### PR TITLE
 Make repo more binder friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TIBHannover/orkg-lsuc-jn/master)
+
+Supplementary material to Stocker et al. "Towards research infrastructures that curate scientific information: A use case in life sciences" originally submitted to the [13th International Conference on Data Integration in the Life Sciences](https://events.tib.eu/dils2018/) (DILS 2018), November 20-21, Hannover, Germany.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TIBHannover/orkg-lsuc-jn/master)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/TIBHannover/orkg-lsuc-jn/master?urlpath=lab)
 
 Supplementary material to Stocker et al. "Towards research infrastructures that curate scientific information: A use case in life sciences" originally submitted to the [13th International Conference on Data Integration in the Life Sciences](https://events.tib.eu/dils2018/) (DILS 2018), November 20-21, Hannover, Germany.

--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -19,15 +19,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install numpy pandas scipy rdflib matplotlib"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import io\n",
     "import re\n",
     "import requests\n",
@@ -382,7 +373,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy==1.15.4
+pandas==0.23.4
+scipy==1.1.0
+rdflib==4.2.2
+matplotlib==3.0.2
+requests==2.20.1


### PR DESCRIPTION
As binder automatically installs from requirements.txt the users don't
need to install the requirements them self. Also the versions are pinned
for reproducibility and a link to binder is added.